### PR TITLE
Fix checkpoint sync url format, fix wording

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -29,8 +29,8 @@ fields:
     title: Checkpoint for fast sync
     description: >-
       To get Teku up and running in only a few minutes, you can start Teku from a recent finalized checkpoint state rather than syncing from genesis. This is substantially **faster** and consumes **less resources** than syncing from genesis, while still providing all the same features. Be sure you are using a trusted node for the fast sync. Check [Teku docs](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Checkpoint-Start/)
-      Use the dappnode official endpoint **https://checkpoint-sync.dappnode.io** or get your checkpoint sync from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-chain.infura.io)
-      Note If you are going to use your check sync point url, to use it make sure you dont use a slash (/) at the end of the url.
+      Use the dappnode official endpoint `https://checkpoint-sync.dappnode.io` or get your checkpoint sync from [Infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-chain.infura.io)
+      *Note If you are going to use your own check sync point endpoint, make sure you don not use a slash (/) at the end of the url.*
     required: false
   - id: feeRecipientAddress
     target:


### PR DESCRIPTION
fixed wording for checkpoint sync and made the DAppNode checkpoint sync endpoint URL more easily selectable to copy and paste.