### PR TITLE
Add exit validator option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
       DEFAULT_FEE_RECIPIENT: ""
+      EXIT_VALIDATOR: ""
+      KEYSTORES_VOLUNTARY_EXIT: ""
     restart: unless-stopped
     image: "validator.teku.dnp.dappnode.eth:0.1.0"
 volumes:

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -5,6 +5,22 @@ NETWORK="mainnet"
 VALIDATOR_PORT=3500
 WEB3SIGNER_API="http://web3signer.web3signer.dappnode:9000"
 
+
+if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]]; then
+    echo "Check connectivity with the web3signer"
+    WEB3SIGNER_STATUS=$(curl -s  http://web3signer.web3signer.dappnode:9000/healthcheck | jq '.status')
+    if [[ "$WEB3SIGNER_STATUS" == '"UP"' ]]; then
+    echo "Proceeds to do the voluntary exit of the next keystores:"
+    echo "$KEYSTORES_VOLUNTARY_EXIT"
+    echo yes | exec /opt/teku/bin/teku voluntary-exit --beacon-node-api-endpoint=http://beacon-chain.teku.dappnode:3500 \
+        --validators-external-signer-public-keys=$KEYSTORES_VOLUNTARY_EXIT \
+        --validators-external-signer-url=$WEB3SIGNER_API
+    else
+      echo "The web3signer is not running or the teku package has not access to the web3signer"
+    fi
+fi
+
+
 # Teku must start with the current env due to JAVA_HOME var
 exec /opt/teku/bin/teku --log-destination=CONSOLE \
   validator-client \

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -6,7 +6,7 @@ VALIDATOR_PORT=3500
 WEB3SIGNER_API="http://web3signer.web3signer.dappnode:9000"
 
 
-if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]]; then
+if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]] && ! [ -z "$KEYSTORES_VOLUNTARY_EXIT" ]; then
     echo "Check connectivity with the web3signer"
     WEB3SIGNER_STATUS=$(curl -s  http://web3signer.web3signer.dappnode:9000/healthcheck | jq '.status')
     if [[ "$WEB3SIGNER_STATUS" == '"UP"' ]]; then
@@ -16,7 +16,8 @@ if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]]; then
         --validators-external-signer-public-keys=$KEYSTORES_VOLUNTARY_EXIT \
         --validators-external-signer-url=$WEB3SIGNER_API
     else
-      echo "The web3signer is not running or the teku package has not access to the web3signer"
+      echo "The web3signer-prater is not running or the teku package has not access to the web3signer"
+      echo "The env var KEYSTORES_VOLUNTARY_EXIT: $KEYSTORES_VOLUNTARY_EXIT has a empty value"
     fi
 fi
 


### PR DESCRIPTION
With this changes the user can do a voluntary exit of their validators, he has to write on 2 env vars:
EXIT_VALIDATOR: I want to exit my validators  he must write exactly that phrase
KEYSTORES_VOLUNTARY_EXIT: In this one, the user would write the keystores in the next format: 0x849384938,0x83948398