### PR TITLE
remove extra ENV variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
         UPSTREAM_VERSION: 22.10.2
     environment:
       BEACON_API_PORT: 3500
-      HTTP_ENGINE: ""
       CHECKPOINT_SYNC_URL: ""
       P2P_PORT: 9105
       EXTRA_OPTS: ""


### PR DESCRIPTION
post StakersUI publication this should not be in the compose file it adds a conflict and confusion since its configurable and carries over whatever was set prior to the stakersUI