### PR TITLE
Fix beacon warning for fee recipient

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -30,6 +30,12 @@ if [ -n "$_DAPPNODE_GLOBAL_MEVBOOST_MAINNET" ] && [ "$_DAPPNODE_GLOBAL_MEVBOOST_
     EXTRA_OPTS="--builder-endpoint=${MEVBOOST_URL} ${EXTRA_OPTS}"
 fi
 
+# If EXTRA_OPTS does not include flag --suggested-fee-recipient, append it
+if [[ $EXTRA_OPTS != *"validators-proposer-default-fee-recipient"* ]]; then
+  echo "Adding --validators-proposer-default-fee-recipient=${FEE_RECIPIENT_ADDRESS} to EXTRA_OPTS"
+  EXTRA_OPTS="--validators-proposer-default-fee-recipient=${FEE_RECIPIENT_ADDRESS} ${EXTRA_OPTS}"
+fi
+
 exec /opt/teku/bin/teku \
     --network=mainnet \
     --data-base-path=/opt/teku/data \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       BEACON_API_PORT: 3500
       CHECKPOINT_SYNC_URL: ""
       P2P_PORT: 9105
+      FEE_RECIPIENT_ADDRESS: ""
       EXTRA_OPTS: ""
     volumes:
       - "teku-data:/opt/teku/data"


### PR DESCRIPTION
Teku beacon chain is showing the following warning: 
 
 `WARN  - Remote Validator Client detected and no default fee recipient has been configured via the validators-proposer-default-fee-recipient option! It is strongly recommended to configure it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.`

This PR fixes it without causing damage to those that have already set this flag in EXTRA_OPTS